### PR TITLE
Add a Dockerfile and usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM cometkim/go-dep-onbuild

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ brew install flog
 
 Download gzip file from [Github Releases](https://github.com/mingrammer/flog/releases/latest) according to your OS. Then, copy the unzipped executable to under system path.
 
-### Using Docker
+### Using [docker](https://www.docker.com)
 
 ```
 docker run -it --rm mingrammer/flog

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ brew install flog
 
 Download gzip file from [Github Releases](https://github.com/mingrammer/flog/releases/latest) according to your OS. Then, copy the unzipped executable to under system path.
 
+### Using Docker
+
+```
+docker run -it --rm mingrammer/flog
+```
+
 ## Usage
 
 There are useful options. (`flog --help`)


### PR DESCRIPTION
Hello @mingrammer 

I suggest you add a Dockerfile to this project. If a user already uses docker can enable it without any installations and easily collaborate with other docker containers.

It would also be great if the generated log out from stdout instead of a file as default.