### PR TITLE
Use go module instead of dep to build the flog docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*.md
+.git
+.idea
+vendor
+dist
+formula

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM cometkim/go-dep-onbuild
+FROM mingrammer/go-mod-onbuild


### PR DESCRIPTION
@cometkim Hi cometkim.

I changed the go package dependency manager from dep to Go module (which is available since Go >= 1.11) with [go-mod-onbuild](https://github.com/mingrammer/go-mod-onbuild). This image was inspired by your [go-dep-onbuild](https://github.com/cometkim/go-dep-onbuild) image.

How do you think about it?