### PR TITLE
Fix wrong RFC3164 timestamp format and add a PRI part

### DIFF
--- a/flog_test.go
+++ b/flog_test.go
@@ -25,7 +25,7 @@ func ExampleNewLog() {
 	// 222.83.191.222 - Kozey7157 697 [2018-04-22T09:30:00Z] "DELETE /innovate/next-generation" 302 24570
 	// 174.144.199.149 - Mosciski7760 386 [2018-04-22T09:30:00Z] "GET /networks/revolutionary" 204 70360 "https://www.directeyeballs.org/streamline" "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_7) AppleWebKit/5312 (KHTML, like Gecko) Chrome/37.0.821.0 Mobile Safari/5312"
 	// [2018-04-22T09:30:00Z] [tempore:warn] [pid 7401:tid 4039] [client: 184.155.77.136] Try to synthesize the SMS capacitor, maybe it will compress the online program!
-	// 2018-04-22T09:30:00Z Wolff5542 Centralized[5680]: Quantifying the capacitor won't do anything, we need to parse the neural SAS program!
+	// <25>Apr 22 09:30:00 Fay5424 Monitored[5455]: Try to reboot the SMS bandwidth, maybe it will synthesize the mobile transmitter!
 	//
 }
 

--- a/log.go
+++ b/log.go
@@ -15,7 +15,7 @@ const (
 	// ApacheErrorLog : [{timestamp}] [{module}:{severity}] [pid {pid}:tid {thread-id}] [client: %{client}] %{message}
 	ApacheErrorLog = "[%s] [%s:%s] [pid %d:tid %d] [client: %s] %s\n"
 	// RFC3164Log : {timestamp} {hostname} {application}[{pid}]: {message}
-	RFC3164Log = "%s %s %s[%d]: %s\n"
+	RFC3164Log = "<%d>%s %s %s[%d]: %s\n"
 )
 
 // NewApacheCommonLog creates a log string with apache common log format
@@ -68,7 +68,8 @@ func NewApacheErrorLog(delta time.Duration) string {
 func NewRFC3164Log(delta time.Duration) string {
 	return fmt.Sprintf(
 		RFC3164Log,
-		time.Now().Add(delta).Format(time.RFC3339),
+		gofakeit.Number(0, 191),
+		time.Now().Add(delta).Format(RFC3164),
 		gofakeit.Username(),
 		gofakeit.BuzzWord(),
 		gofakeit.Number(1, 10000),

--- a/log_test.go
+++ b/log_test.go
@@ -47,5 +47,5 @@ func ExampleNewRFC3164Log() {
 	defer monkey.Unpatch(time.Now)
 
 	fmt.Println(NewRFC3164Log(0))
-	// Output: 2018-04-22T09:30:00Z Daniel2872 info-mediaries[9030]: I'Ll reboot the auxiliary USB protocol, that should sensor the SAS capacitor!
+	// Output: <24>Apr 22 09:30:00 Moen8727 concept[3160]: If we back up the program, we can get to the SSL sensor through the redundant SAS program!
 }

--- a/time.go
+++ b/time.go
@@ -1,0 +1,6 @@
+package main
+
+// Custom predefined layouts
+const (
+	RFC3164 = "Jan 02 15:04:05"
+)


### PR DESCRIPTION
@mtds

I've added RFC3164 timestamp layout and a PRI part to RFC3164 log format.

It resolves #8 