### PR TITLE
Combined log format should use month in timestamp similar to common f…

### DIFF
--- a/flog_test.go
+++ b/flog_test.go
@@ -25,8 +25,8 @@ func ExampleNewLog() {
 	fmt.Println(NewLog("common_log", created))
 	fmt.Println(NewLog("unknown", created))
 	// Output:
-	// 222.83.191.222 - - [22/04/2018:09:30:00 +0000] "DELETE /innovate/next-generation HTTP/1.1" 406 7610
-	// 144.199.149.125 - waelchi7603 [22/04/2018:09:30:00 +0000] "PUT /revolutionary HTTP/1.1" 301 8089 "https://www.futureaggregate.io/users" "Mozilla/5.0 (Macintosh; PPC Mac OS X 10_6_5 rv:4.0; en-US) AppleWebKit/536.38.2 (KHTML, like Gecko) Version/6.0 Safari/536.38.2"
+	// 222.83.191.222 - - [22/Apr/2018:09:30:00 +0000] "DELETE /innovate/next-generation HTTP/1.1" 406 7610
+	// 144.199.149.125 - waelchi7603 [22/Apr/2018:09:30:00 +0000] "PUT /revolutionary HTTP/1.1" 301 8089 "https://www.futureaggregate.io/users" "Mozilla/5.0 (Macintosh; PPC Mac OS X 10_6_5 rv:4.0; en-US) AppleWebKit/536.38.2 (KHTML, like Gecko) Version/6.0 Safari/536.38.2"
 	// [Sun Apr 22 09:30:00 2018] [eaque:error] [pid 3748:tid 2783] [client: 54.26.161.221] We need to transmit the open-source JSON capacitor!
 	// <15>Apr 22 09:30:00 parisian2785 eius[350]: You can't quantify the capacitor without connecting the virtual XSS transmitter!
 	// <12>2 2018-04-22T09:30:00.000Z internalmagnetic.io necessitatibus 3954 ID418 - Try to navigate the AGP feed, maybe it will quantify the optical monitor!

--- a/log_test.go
+++ b/log_test.go
@@ -18,7 +18,7 @@ func ExampleNewApacheCommonLog() {
 
 	created := time.Now()
 	fmt.Println(NewApacheCommonLog(created))
-	// Output: 222.83.191.222 - - [22/04/2018:09:30:00 +0000] "DELETE /innovate/next-generation HTTP/1.1" 406 7610
+	// Output: 222.83.191.222 - - [22/Apr/2018:09:30:00 +0000] "DELETE /innovate/next-generation HTTP/1.1" 406 7610
 }
 
 func ExampleNewApacheCombinedLog() {
@@ -29,7 +29,7 @@ func ExampleNewApacheCombinedLog() {
 
 	created := time.Now()
 	fmt.Println(NewApacheCombinedLog(created))
-	// Output: 222.83.191.222 - - [22/04/2018:09:30:00 +0000] "DELETE /innovate/next-generation HTTP/1.1" 406 97484 "https://www.humanscalable.io/synergize/morph/sticky" "Mozilla/5.0 (Windows NT 5.01) AppleWebKit/5320 (KHTML, like Gecko) Chrome/40.0.875.0 Mobile Safari/5320"
+	// Output: 222.83.191.222 - - [22/Apr/2018:09:30:00 +0000] "DELETE /innovate/next-generation HTTP/1.1" 406 97484 "https://www.humanscalable.io/synergize/morph/sticky" "Mozilla/5.0 (Windows NT 5.01) AppleWebKit/5320 (KHTML, like Gecko) Chrome/40.0.875.0 Mobile Safari/5320"
 }
 
 func ExampleNewApacheErrorLog() {

--- a/time.go
+++ b/time.go
@@ -2,7 +2,7 @@ package main
 
 // Custom predefined layouts
 const (
-	Apache      = "02/01/2006:15:04:05 -0700"
+	Apache      = "02/Jan/2006:15:04:05 -0700"
 	ApacheError = "Mon Jan 02 15:04:05 2006"
 	RFC3164     = "Jan 02 15:04:05"
 	RFC5424     = "2006-01-02T15:04:05.000Z"


### PR DESCRIPTION
The Apache common format uses 3 letters for the month. According to the Apache docs on [combined format](https://httpd.apache.org/docs/2.4/logs.html#combined), the combined format is similar to the common format and has two additional fields alone. Hence, combined format should be changed to use the 3 letter month instead of digit.

