### PR TITLE
Fix apache error log format

### DIFF
--- a/flog_test.go
+++ b/flog_test.go
@@ -27,10 +27,10 @@ func ExampleNewLog() {
 	// Output:
 	// 222.83.191.222 - - [22/Apr/2018:09:30:00 +0000] "DELETE /innovate/next-generation HTTP/1.1" 406 7610
 	// 144.199.149.125 - waelchi7603 [22/Apr/2018:09:30:00 +0000] "PUT /revolutionary HTTP/1.1" 301 8089 "https://www.futureaggregate.io/users" "Mozilla/5.0 (Macintosh; PPC Mac OS X 10_6_5 rv:4.0; en-US) AppleWebKit/536.38.2 (KHTML, like Gecko) Version/6.0 Safari/536.38.2"
-	// [Sun Apr 22 09:30:00 2018] [eaque:error] [pid 3748:tid 2783] [client: 54.26.161.221] We need to transmit the open-source JSON capacitor!
-	// <15>Apr 22 09:30:00 parisian2785 eius[350]: You can't quantify the capacitor without connecting the virtual XSS transmitter!
-	// <12>2 2018-04-22T09:30:00.000Z internalmagnetic.io necessitatibus 3954 ID418 - Try to navigate the AGP feed, maybe it will quantify the optical monitor!
-	// 7.101.102.40 - dibbert8018 [22/Apr/2018:09:30:00 +0000] "PATCH /empower/leading-edge/markets/whiteboard HTTP/1.0" 502 21224
+	// [Sun Apr 22 09:30:00 2018] [eaque:error] [pid 3748:tid 2783] [client 54.26.161.221:31944] Backing up the program won't do anything, we need to compress the optical PCI bandwidth!
+	// <94>Apr 22 09:30:00 ortiz5384 vel[1775]: If we copy the firewall, we can get to the PCI firewall through the redundant SQL port!
+	// <23>3 2018-04-22T09:30:00.000Z humaniterate.io iusto 544 ID177 - Use the optical RAM hard drive, then you can program the auxiliary feed!
+	// 195.44.200.155 - kihn6187 [22/Apr/2018:09:30:00 +0000] "GET /revolutionary/e-markets/holistic/syndicate HTTP/2.0" 404 14503
 	//
 }
 

--- a/log.go
+++ b/log.go
@@ -13,8 +13,8 @@ const (
 	ApacheCommonLog = "%s - %s [%s] \"%s %s %s\" %d %d"
 	// ApacheCombinedLog : {host} {user-identifier} {auth-user-id} [{datetime}] "{method} {request} {protocol}" {response-code} {bytes} "{referrer}" "{agent}"
 	ApacheCombinedLog = "%s - %s [%s] \"%s %s %s\" %d %d \"%s\" \"%s\""
-	// ApacheErrorLog : [{timestamp}] [{module}:{severity}] [pid {pid}:tid {thread-id}] [client: %{client}] %{message}
-	ApacheErrorLog = "[%s] [%s:%s] [pid %d:tid %d] [client: %s] %s"
+	// ApacheErrorLog : [{timestamp}] [{module}:{severity}] [pid {pid}:tid {thread-id}] [client %{client}:{port}] %{message}
+	ApacheErrorLog = "[%s] [%s:%s] [pid %d:tid %d] [client %s:%d] %s"
 	// RFC3164Log : <priority>{timestamp} {hostname} {application}[{pid}]: {message}
 	RFC3164Log = "<%d>%s %s %s[%d]: %s"
 	// RFC5424Log : <priority>{version} {iso-timestamp} {hostname} {application} {pid} {message-id} {structured-data} {message}
@@ -65,6 +65,7 @@ func NewApacheErrorLog(t time.Time) string {
 		gofakeit.Number(1, 10000),
 		gofakeit.Number(1, 10000),
 		gofakeit.IPv4Address(),
+		gofakeit.Number(1, 65535),
 		gofakeit.HackerPhrase(),
 	)
 }

--- a/log_test.go
+++ b/log_test.go
@@ -40,7 +40,7 @@ func ExampleNewApacheErrorLog() {
 
 	created := time.Now()
 	fmt.Println(NewApacheErrorLog(created))
-	// Output: [Sun Apr 22 09:30:00 2018] [quia:crit] [pid 4214:tid 6037] [client: 90.151.9.107] If we back up the program, we can get to the SSL sensor through the redundant SAS program!
+	// Output: [Sun Apr 22 09:30:00 2018] [quia:crit] [pid 4214:tid 6037] [client 90.151.9.107:14075] Copying the protocol won't do anything, we need to copy the redundant SAS program!
 }
 
 func ExampleNewRFC3164Log() {


### PR DESCRIPTION
From this [apache documentation](https://httpd.apache.org/docs/2.4/fr/mod/core.html#errorlogformat): we should have something like `[client %{client}:{port}]` instead of `[client: %{client}]`