### PR TITLE
Remove dep reference as the project migrated to go modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ It is useful for testing some tasks which require log data like amazon kinesis l
 go get -u github.com/mingrammer/flog
 ```
 
-It is recommended to also run `dep ensure` to make sure that the dependencies are in the correct versions.
-
 ### Using [homebrew](https://brew.sh)
 
 ```


### PR DESCRIPTION
Remove dep reference as the project migrated to go modules