### PR TITLE
RFC5424Log structured data

### DIFF
--- a/flog_test.go
+++ b/flog_test.go
@@ -30,10 +30,10 @@ func ExampleNewLog() {
 	// 144.199.149.125 - waelchi7603 [22/Apr/2018:09:30:00 +0000] "PUT /revolutionary HTTP/1.1" 301 8089 "https://www.futureaggregate.io/users" "Mozilla/5.0 (Macintosh; PPC Mac OS X 10_6_5 rv:4.0; en-US) AppleWebKit/536.38.2 (KHTML, like Gecko) Version/6.0 Safari/536.38.2"
 	// [Sun Apr 22 09:30:00 2018] [eaque:error] [pid 3748:tid 2783] [client 54.26.161.221:31944] Backing up the program won't do anything, we need to compress the optical PCI bandwidth!
 	// <94>Apr 22 09:30:00 ortiz5384 vel[1775]: If we copy the firewall, we can get to the PCI firewall through the redundant SQL port!
-	// <23>3 2018-04-22T09:30:00.000Z humaniterate.io iusto 544 ID177 - Use the optical RAM hard drive, then you can program the auxiliary feed!
-	// 195.44.200.155 - kihn6187 [22/Apr/2018:09:30:00 +0000] "GET /revolutionary/e-markets/holistic/syndicate HTTP/2.0" 404 14503
+	// <23>3 2018-04-22T09:30:00.000Z humaniterate.io iusto 544 ID177 [exampleSDID@877061 iut="6" eventSource="Application" eventID="380001"][examplePriority@86525 class="high" method="PUT" uri="/empower/leading-edge/benchmark" status_code="400" time_millis="80" remote_host="190.67.164.175" remote_ip_addr="116.227.143.59"] We need to program the open-source ADP pixel!
+	// 15.48.13.108 - - [22/Apr/2018:09:30:00 +0000] "POST /cross-platform/extensible/out-of-the-box/architectures HTTP/2.0" 100 16077
 	//
-	// {"host":"13.108.182.26", "user-identifier":"bailey7205", "datetime":"22/Apr/2018:09:30:00 +0000", "method": "GET", "request": "/out-of-the-box/architectures/embrace", "protocol":"HTTP/1.0", "status":200, "bytes":5921, "referer": "http://www.dynamicexperiences.io/robust"}
+	// {"host":"11.53.30.203", "user-identifier":"wilkinson1680", "datetime":"22/Apr/2018:09:30:00 +0000", "method": "POST", "request": "/bleeding-edge/morph", "protocol":"HTTP/2.0", "status":502, "bytes":10203, "referer": "https://www.globale-enable.net/leverage/integrated"}
 }
 
 func TestNewSplitFileName(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	bou.ke/monkey v1.0.2
 	github.com/brianvoe/gofakeit v3.11.5+incompatible
+	github.com/influxdata/go-syslog v1.0.1
 	github.com/mingrammer/cfmt v1.0.0
 	github.com/spf13/pflag v1.0.0
 	github.com/stretchr/testify v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.6.0 h1:66qjqZk8kalYAvDRtM1AdAJQI0tj4Wrue3Eq3B3pmFU=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/influxdata/go-syslog v1.0.1 h1:a/ARpnCDr/sX/hVH7dyQVi+COXlEzM4bNIoolOfw99Y=
+github.com/influxdata/go-syslog v1.0.1/go.mod h1:zAVA46ROTGBUi5zyIJODjMJYJKy+ooglXp0X3LgoIUE=
 github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3 h1:ns/ykhmWi7G9O+8a448SecJU3nSMBXJfqQkl0upE1jI=

--- a/log.go
+++ b/log.go
@@ -87,6 +87,23 @@ func NewRFC3164Log(t time.Time) string {
 
 // NewRFC5424Log creates a log string with syslog (RFC5424) format
 func NewRFC5424Log(t time.Time) string {
+	structuredData := func() string {
+		// Valid examples	https://datatracker.ietf.org/doc/html/rfc5424#section-6.3.5
+		structuredFormat := "[exampleSDID@%d iut=\"%d\" eventSource=\"Application\" eventID=\"%d\"][examplePriority@%d class=\"high\" method=\"%s\" uri=\"%s\" status_code=\"%d\" time_millis=\"%d\" remote_host=\"%s\" remote_ip_addr=\"%s\"]"
+		return fmt.Sprintf(
+			structuredFormat,
+			gofakeit.Number(100000, 900000),
+			gofakeit.Number(1, 10),
+			gofakeit.Number(100, 999999),
+			gofakeit.Number(10000, 99999),
+			gofakeit.HTTPMethod(),
+			RandResourceURI(),
+			gofakeit.StatusCode(),
+			gofakeit.Number(1, 300),
+			gofakeit.IPv4Address(),
+			gofakeit.IPv4Address(),
+		)
+	}
 	return fmt.Sprintf(
 		RFC5424Log,
 		gofakeit.Number(0, 191),
@@ -96,7 +113,7 @@ func NewRFC5424Log(t time.Time) string {
 		gofakeit.Word(),
 		gofakeit.Number(1, 10000),
 		gofakeit.Number(1, 1000),
-		"-", // TODO: structured data
+		structuredData(),
 		gofakeit.HackerPhrase(),
 	)
 }

--- a/log_test.go
+++ b/log_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"fmt"
 	"math/rand"
+	"testing"
 	"time"
 
 	"bou.ke/monkey"
+	"github.com/influxdata/go-syslog/rfc5424"
 )
 
 var stopped = time.Date(2018, 04, 22, 9, 30, 0, 0, time.UTC)
@@ -62,7 +64,26 @@ func ExampleNewRFC5424Log() {
 
 	created := time.Now()
 	fmt.Println(NewRFC5424Log(created))
-	// Output: <24>3 2018-04-22T09:30:00.000Z futurefunctionalities.biz nisi 9030 ID160 - If we back up the program, we can get to the SSL sensor through the redundant SAS program!
+	// Output: <24>3 2018-04-22T09:30:00.000Z futurefunctionalities.biz nisi 9030 ID160 [exampleSDID@384101 iut="9" eventSource="Application" eventID="563169"][examplePriority@48929 class="high" method="DELETE" uri="/revolutionary/benchmark" status_code="406" time_millis="97" remote_host="199.149.125.36" remote_ip_addr="116.222.184.135"] The PCI firewall is down, parse the multi-byte interface so we can connect the SAS program!
+}
+
+func TestNewRFC5424LogParse(t *testing.T) {
+	rand.Seed(11)
+
+	monkey.Patch(time.Now, func() time.Time { return stopped })
+	defer monkey.Unpatch(time.Now)
+
+	created := time.Now()
+	rfc5424text := NewRFC5424Log(created)
+	rfc5424bytes := []byte(rfc5424text)
+	withBestEffort := false
+
+	p := rfc5424.NewParser()
+	_, err := p.Parse(rfc5424bytes, &withBestEffort)
+	if err != nil {
+		t.Errorf("Error parsing: '%s'", err)
+	}
+
 }
 
 func ExampleNewCommonLogFormat() {


### PR DESCRIPTION
Added structured data part for **rfc5424** log type according to https://datatracker.ietf.org/doc/html/rfc5424

Sample rfc5424 log:
```
<125>1 2022-03-16T17:00:56.983Z seniorpartnerships.net aut 5073 ID698 [exampleSDID@353664 iut="8" eventSource="Application" eventID="306249"][examplePriority@97903 class="high" method="POST" uri="/granular/sexy/integrate" status_code="504" time_millis="186" remote_host="128.200.83.221" remote_ip_addr="156.235.138.200"] If we back up the interface, we can get to the JBOD capacitor through the neural XML bus!
```
the structured data
``` [exampleSDID@353664 iut="8" eventSource="Application" eventID="306249"][examplePriority@97903 class="high" method="POST" uri="/granular/sexy/integrate" status_code="504" time_millis="186" remote_host="128.200.83.221" remote_ip_addr="156.235.138.200"]```
consist of two parts inside square brackets(`[...][...]`), which is valid and I think it is good for testing rfc5424 parser.